### PR TITLE
Check data !== before returning `flattenEntityResponse` in `flattenDeep`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,8 @@ export function flattenDeep<T extends StrapiEntityResponse|StrapiEntityResponseC
             if (isFlattenable(value)) {
                 if ('data' in value && Array.isArray((value as any).data)) {
                     result[key] = flattenEntityResponseCollection(value);
-                } else {
+                }
+                if (value.data) {
                     result[key] = flattenEntityResponse(value);
                 }
             } else {


### PR DESCRIPTION
Without this check, deeply nested componets inisde large queries can fail, throwing error: `Error: wrong entity response`.